### PR TITLE
Add page to view available communities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 venv/
 .vscode/
+nlnog-lg.conf

--- a/nlnog_lg.py
+++ b/nlnog_lg.py
@@ -75,9 +75,10 @@ def read_communities():
                 (asn, value) = comm.split(":", 1)
                 if value.isnumeric():
                     if asn not in communitylist:
-                        communitylist[asn] = {"exact": {comm: desc}, "re": [], "range": []}
+                        communitylist[asn] = {"exact": {comm: desc}, "re": [], "range": [], "raw" : {}}
                     else:
                         communitylist[asn]["exact"][comm] = desc
+                        communitylist[asn]["raw"][comm] = desc
                 else:
                     # funky notations:
                     # nnn -> any number
@@ -101,9 +102,10 @@ def read_communities():
                             communitylist[asn]["range"].append((first, last, desc))
                     if regex:
                         if asn not in communitylist:
-                            communitylist[asn] = {"exact": {}, "re": [(regex, desc)], "range": []}
+                            communitylist[asn] = {"exact": {}, "re": [(regex, desc)], "range": [], "raw": {}}
                         else:
                             communitylist[asn]["re"].append((regex, desc))
+                            communitylist[asn]["raw"][comm] = desc
 
     return communitylist
 
@@ -477,6 +479,16 @@ def communitylist():
         communities.append((community, get_asn_name(str(community))))
 
     return render_template("communities.html", communities=communities)
+
+@app.route('/communitylist/<asn>')
+def communitylist_specific(asn):
+    asn = unquote(asn.strip())
+    communitylist = read_communities()
+    if asn not in communitylist:
+        abort(400)
+
+    return render_template("communities-specific.html", ASN=asn, communities=communitylist[asn]["raw"])
+
 
 @app.errorhandler(400)
 def incorrect_request(_: str):

--- a/templates/communities-specific.html
+++ b/templates/communities-specific.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+{% block body %}
+<br/>
+<h2>
+   Known BGP communities for AS{{ASN}}
+</h2>
+<p>
+Community descriptions are available for the following ASNs:
+</p>
+<table class="table table-striped table-bordered table-condensed table-summary">
+    <thead>
+        <tr>
+            <td>Community</td>
+            <td>Description</td>
+        </tr>
+    </thead>
+    <tbody>
+      {% for community, desc in communities.items() %}
+      <tr class="{{ loop.cycle('odd', 'even') }}">
+          <td class="text-end">{{community}}</td>
+          <td>{{desc}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}

--- a/templates/communities.html
+++ b/templates/communities.html
@@ -15,13 +15,13 @@ Community descriptions are available for the following ASNs:
     <thead>
         <tr>
             <td>ASN</td>
-            <td>description</td>
+            <td>Description</td>
         </tr>
     </thead>
     <tbody>
         {% for asn, desc in communities %}
         <tr class="{{ loop.cycle('odd', 'even') }}">
-            <td class="text-end">{{asn}}</td>
+            <td class="text-end"><a href="/communitylist/{{asn}}">{{asn}}</a></td>
             <td>{{desc}}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
Quick page add to list out the specific communities available for each ASN.

I realised after creating this that the logic used for viewing ASN should be different than the way they're processed for matching. This is due to some network operators using ASNs in the private range for the first two octets. I may rework it later but this is good enough for now.

Please let me know if you have any queries.