### PR TITLE
Add AS34953 Communities

### DIFF
--- a/communities/as34953.txt
+++ b/communities/as34953.txt
@@ -1,0 +1,6 @@
+# documented at 'whois -h whois.ripe.net as34953'
+34953:10000,own route
+34953:10001,customer route
+34953:10002,private peering route
+34953:10003,public peering route
+34953:10004,transit route


### PR DESCRIPTION
Documented at `whois -h whois.ripe.net as34953`.